### PR TITLE
[PR] Refactoring model management

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,8 +33,6 @@ RUN mix local.hex --force && \
 
 # set build ENV
 ENV MIX_ENV="prod"
-ENV BUMBLEBEE_CACHE_DIR="/app/.bumblebee/"
-
 
 # install mix dependencies
 COPY mix.exs mix.lock ./
@@ -102,7 +100,5 @@ USER nobody
 # Set the runtime ENV
 ENV ECTO_IPV6="true"
 ENV ERL_AFLAGS="-proto_dist inet6_tcp"
-ENV BUMBLEBEE_CACHE_DIR="/app/.bumblebee/"
-
 
 CMD ["/app/bin/server"]

--- a/README.md
+++ b/README.md
@@ -1411,6 +1411,14 @@ Awesome! 🎉
 > and more resources your server will need to have to handle this heavier workload.
 
 
+> [!WARNING]
+>
+> We've created a small module that allows you to have multiple models
+> cached and downloaded and keep this logic contained.
+>
+> For this, check the [`deployment guide`](./deployment.md#5-a-better-model-management).
+
+
 # 7. How do I deploy this thing?
 
 There are a few considerations you may want to have

--- a/config/config.exs
+++ b/config/config.exs
@@ -63,4 +63,4 @@ import_config "#{config_env()}.exs"
 # After deploying, you set it to `false` and deploy it again,
 # so the application doesn't download the model again on every restart.
 config :app,
-  force_models_download: false
+  models_cache_dir: ".bumblebee"

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -63,7 +63,3 @@ config :phoenix, :stacktrace_depth, 20
 
 # Initialize plugs at runtime for faster development compilation
 config :phoenix, :plug_init_mode, :runtime
-
-# App configuration
-config :app,
-  models_cache_dir: ".bumblebee"

--- a/config/test.exs
+++ b/config/test.exs
@@ -15,6 +15,4 @@ config :phoenix, :plug_init_mode, :runtime
 
 # App configuration
 config :app,
-  use_test_models: true,
-  force_models_download: true,
-  models_cache_dir: ".bumblebee"
+  use_test_models: true

--- a/deployment.md
+++ b/deployment.md
@@ -1597,8 +1597,12 @@ config :app,
 
 **This flag will make it so the application wipes out the models cache folder and download the new ones.**
 
-Run `fly deploy` 
+Run `fly deploy --no-cache` 
 and let it finish.
+After deploying, make sure the application has started,
+so the cache is correctly purged
+(you can force the application to start
+by visiting the URL).
 
 But now we have to
 **re-deploy it again**,

--- a/deployment.md
+++ b/deployment.md
@@ -31,7 +31,7 @@ Let's start 🏃‍♂️.
     - [4.3 Confirm that the volume is attached to the machine](#43-confirm-that-the-volume-is-attached-to-the-machine)
     - [4.4 Extending the size of the volume](#44-extending-the-size-of-the-volume)
     - [4.5 Running the application and checking new volume size and its usage](#45-running-the-application-and-checking-new-volume-size-and-its-usage)
-  - [5. Forcing re-download](#5-forcing-re-download)
+  - [5. A better model management](#5-a-better-model-management)
     - [5.1. Why are you not using `Mix.env/0`?](#51-why-are-you-not-using-mixenv0)
 - [Scaling up `fly` machines](#scaling-up-fly-machines)
   - [1. Creating another `machine` and `volume` pair](#1-creating-another-machine-and-volume-pair)
@@ -39,7 +39,7 @@ Let's start 🏃‍♂️.
 - [Moving to a better model](#moving-to-a-better-model)
   - [1. Scale the machine to a better preset](#1-scale-the-machine-to-a-better-preset)
   - [2. Change your model](#2-change-your-model)
-  - [3. Deploy... and deploy again!](#3-deploy-and-deploy-again)
+  - [3. Deploy... (and deploy again?)](#3-deploy-and-deploy-again)
 
 
 # Considerations before you deploy
@@ -796,22 +796,32 @@ and persisted to a volume.
 So we know we won't lose this data in-between app restarts!
 
 
-## 5. Forcing re-download
+## 5. A better model management
 
 Sometimes we make change to the code 
 and we want to use other models.
 As it stands, if the models cache directory is populated,
 it won't download any new models.
 
-We can allow the person to **force re-downloading the models**.
-While we're at it, 
-we can move all of this logic to a different module so it's easier for us to manage it!
+This is a **great opportunity to make our own model management model**.
+This means that we are going to move our move 
+all our logic regarding models in `application.ex`
+to its own model!
 
 Let's do it!
 
 In `lib/app`, create a file called `models.ex`.
 
 ```elixir
+defmodule ModelInfo do
+  @doc """
+  Information regarding the model being loaded.
+  It holds the name of the model repository and the directory it will be saved into.
+  It also has booleans to load each model parameter at will - this is because some models (like BLIP) require featurizer, tokenizations and generation configuration.
+  """
+  defstruct [:name, :cache_path, :load_featurizer, :load_tokenizer, :load_generation_config]
+end
+
 defmodule App.Models do
   @moduledoc """
   Manages loading the modules and their location according to env.
@@ -819,44 +829,57 @@ defmodule App.Models do
   require Logger
 
   # IMPORTANT: This should be the same directory as defined in the `Dockerfile`.
-  @models_folder_path Path.join(
-                        System.get_env("BUMBLEBEE_CACHE_DIR") ||
-                          Application.compile_env!(:app, :models_cache_dir),
-                        "huggingface"
-                      )
+  @models_folder_path Application.compile_env!(:app, :models_cache_dir)
+
+  # Test and prod models information
+  @test_model %ModelInfo{
+    name: "microsoft/resnet-50",
+    cache_path: Path.join(@models_folder_path, "resnet-50"),
+    load_featurizer: true
+  }
+  def extract_test_label(result) do %{predictions: [%{label: label}]} = result; label end
+
+  @prod_model %ModelInfo{
+    name: "Salesforce/blip-image-captioning-base",
+    cache_path: Path.join(@models_folder_path, "blip-image-captioning-base"),
+    load_featurizer: true,
+    load_tokenizer: true,
+    load_generation_config: true
+  }
+  def extract_prod_label(result) do %{results: [%{text: label}]} = result; label end
 
   @doc """
-  Verifies if downloaded models folder is populated or not.
-  We clear the folder and re-download the models if:
-  - the directory is empty.
-  - `force_download` in configs is set to `true`.
-  - `use_test_models` in configs is set to `true`.
+  Verifies and downloads the models according to configuration
+  and if they are already cached locally or not.
   """
   def verify_and_download_models() do
-
     force_models_download = Application.get_env(:app, :force_models_download, false)
     use_test_models = Application.get_env(:app, :use_test_models, false)
 
-    # Re-download the models
-    if not File.exists?(@models_folder_path) or File.ls!(@models_folder_path) == [] or
-    force_models_download == true or
-    use_test_models == true do
+    case {force_models_download, use_test_models} do
+      {true, true} ->
+        File.rm_rf!(@models_folder_path) # Delete any cached pre-existing models
+        download_model(@test_model)      # Download test models
 
-      # Delete any pre-existing models
-      Logger.info("Deleting models...")
-      File.rm_rf!(@models_folder_path)
+      {true, false} ->
+        File.rm_rf!(@models_folder_path) # Delete any cached pre-existing models
+        download_model(@prod_model)      # Download prod models
 
-      # Download the models according to env
-      Logger.info(
-        "Downloading the models..."
-      )
-      case use_test_models do
-        true ->
-          download_models_test()
+      {false, false} ->
+        # Check if the prod model cache directory exists or if it's not empty.
+        # If so, we download the prod model.
+        model_location = Path.join(@prod_model.cache_path, "huggingface")
+        if not File.exists?(model_location) or File.ls!(model_location) == [] do
+          download_model(@prod_model)
+        end
 
-        _ ->
-          download_models()
-      end
+      {false, true} ->
+        # Check if the test model cache directory exists or if it's not empty.
+        # If so, we download the test model.
+        model_location = Path.join(@test_model.cache_path, "huggingface")
+        if not File.exists?(model_location) or File.ls!(model_location) == [] do
+          download_model(@test_model)
+        end
     end
   end
 
@@ -867,12 +890,13 @@ defmodule App.Models do
   This assumes the models that are being used exist locally, in the @models_folder_path.
   """
   def serving do
-    # ResNet-50 -----
-    {:ok, model_info} = Bumblebee.load_model({:hf, "microsoft/resnet-50", offline: true})
-    {:ok, featurizer} = Bumblebee.load_featurizer({:hf, "microsoft/resnet-50", offline: true})
+    model = load_offline_model(@prod_model)
 
-    Bumblebee.Vision.image_classification(model_info, featurizer,
-      top_k: 1,
+    Bumblebee.Vision.image_to_text(
+      model.model_info,
+      model.featurizer,
+      model.tokenizer,
+      model.generation_config,
       compile: [batch_size: 10],
       defn_options: [compiler: EXLA],
       # needed to run on `Fly.io`
@@ -882,14 +906,14 @@ defmodule App.Models do
 
   @doc """
   Serving function for tests only.
-  Downloads `ResNet-50`, since it's lightweight.
+  This function is meant to be called and served by `Nx` in `lib/app/application.ex`.
+
+  This assumes the models that are being used exist locally, in the @models_folder_path.
   """
   def serving_test do
-    # ResNet-50 -----
-    {:ok, model_info} = Bumblebee.load_model({:hf, "microsoft/resnet-50", offline: true})
-    {:ok, featurizer} = Bumblebee.load_featurizer({:hf, "microsoft/resnet-50", offline: true})
+    model = load_offline_model(@test_model)
 
-    Bumblebee.Vision.image_classification(model_info, featurizer,
+    Bumblebee.Vision.image_classification(model.model_info, model.featurizer,
       top_k: 1,
       compile: [batch_size: 10],
       defn_options: [compiler: EXLA],
@@ -898,79 +922,151 @@ defmodule App.Models do
     )
   end
 
-  # Downloads the models for the test environment.
-  # Downloads `ResNet-50`, which is fairly lightweight
-  # (if you change the model, make sure to change `handle_info/3` in `page_live.ex`
-  # so extracting the output from the model works properly with the one you've chosen).
-  defp download_models_test do
-    # ResNet-50 -----
-    {:ok, _} = Bumblebee.load_model({:hf, "microsoft/resnet-50"})
-    {:ok, _} = Bumblebee.load_featurizer({:hf, "microsoft/resnet-50"})
+  # Loads the models from the cache folder.
+  # It will load the model and the respective the featurizer, tokenizer and generation config if needed,
+  # and return a map with all of these at the end.
+  defp load_offline_model(model) do
+    Logger.info("Loading #{model.name}...")
+
+    # Loading model
+    loading_settings = {:hf, model.name, cache_dir: model.cache_path, offline: true}
+    {:ok, model_info} = Bumblebee.load_model(loading_settings)
+
+    info = %{model_info: model_info}
+
+    # Load featurizer, tokenizer and generation config if needed
+    info =
+      if(model.load_featurizer) do
+        {:ok, featurizer} = Bumblebee.load_featurizer(loading_settings)
+        Map.put(info, :featurizer, featurizer)
+      else
+        info
+      end
+
+    info =
+      if(model.load_tokenizer) do
+        {:ok, tokenizer} = Bumblebee.load_tokenizer(loading_settings)
+        Map.put(info, :tokenizer, tokenizer)
+      else
+        info
+      end
+
+    info =
+      if(model.load_generation_config) do
+        {:ok, generation_config} =
+          Bumblebee.load_generation_config(loading_settings)
+
+        Map.put(info, :generation_config, generation_config)
+      else
+        info
+      end
+
+    # Return a map with the model and respective parameters.
+    info
   end
 
-  # Downloads the models used in the production environment.
-  # They must download the same models that are used in the `serving/0` function for this to work.
-  defp download_models do
-    # ResNet-50 -----
-    {:ok, _} = Bumblebee.load_model({:hf, "microsoft/resnet-50"})
-    {:ok, _} = Bumblebee.load_featurizer({:hf, "microsoft/resnet-50"})
+  # Downloads the models according to a given %ModelInfo struct.
+  # It will load the model and the respective the featurizer, tokenizer and generation config if needed.
+  defp download_model(model) do
+    Logger.info("Downloading #{model.name}...")
+
+    # Download model
+    downloading_settings = {:hf, model.name, cache_dir: model.cache_path}
+    Bumblebee.load_model(downloading_settings)
+
+    # Download featurizer, tokenizer and generation config if needed
+    if(model.load_featurizer) do
+      Bumblebee.load_featurizer(downloading_settings)
+    end
+
+    if(model.load_tokenizer) do
+      Bumblebee.load_tokenizer(downloading_settings)
+    end
+
+    if(model.load_generation_config) do
+      Bumblebee.load_generation_config(downloading_settings)
+    end
   end
 end
 ```
 
 There's a lot to unpack here!
 
+- we created a `ModelInfo` struct that holds the information
+regarding a model.
+This struct has information regarding:
+
+  - its `name`, the name of the repository of the model in `HuggingFace`.
+  - the location where they'll be cached (`cache_path`).
+  - booleans for loading different model parameters
+(featurizer, tokenizers and generation configuration).
+
 - we've created a module constant called **`@models_folder_path`**,
 pertaining to the path where the models will be downloaded to.
-This path is the same as the one defined in `BUMBLEBEE_CACHE_DIR`,
-with `huggingface` appended to it.
-Optionally, you can define a configuration variable in `config/test.exs`
-to define the location where the tests will be downloaded during tests.
+This path should be configured in `config/config.exs` file.
 
 ```elixir
 config :app,
-  use_test_models: true,
-  force_models_download: true,
   models_cache_dir: ".bumblebee"
 ```
 
-> [!NOTE]
-> The `use_test_models` and `force_models_download`
-> are going to be used later.
+- added two additional module constants: 
+**`@test_model`** and **`@prod_model`**,
+variables with the `ModelInfo` struct.
+Each constant also has a function that is utilized
+to extract the output of the model.
+If notice that the `cache_path` makes use of the `@models_folder_path`,
+creating a folder for each model.
 
 - **`verify_and_download_models/0`**, as the name entails,
-checks if the model cache directory is empty or not.
-If it's empty, it downloads the models 
-by calling `download_models_test/0` (if it's a `:test` env)
-or by calling `download_models_prod/0` (if it's not a `:test` env).
+checks if the models are cached or not and if they should be re-downloaded.
+The behaviour of this function changes according to the environment it's being executed on
+(`:test` or `:prod`).
+Essentially, we are checking if two configuration variables are defined:
+`force_models_download` and `use_test_models` which
+force the models to be downloaded regardless if they are already cached
+and use the tests models (to be used when testing), respectively.
 
-We can override this behaviour by setting `force_models_download`
-in either `config/test.exs` or `config/prod.exs`.
-This will make the application
-forcefully download the models,
-which can be useful when you want to deploy
-a different model to `fly.io`.
+It is useful to define these behaviours in the configuration files
+in the `config` folder.
+Therefore, it makes sense to add the following lines
+to `config/test.exs`,
+so test models are used (which are more lightweight).
 
 ```elixir
 config :app,
-  force_models_download: true
+  use_test_models: true
 ```
+
+You can define `force_models_download: true` if you want to force the models to be downloaded
+every time the application starts.
+This is generally not recommended.
+It only makes sense if you think a model has been updated
+and you want to the cache to be deprecated
+and be forced to download.
+
+- the **`download_model/1`** function downloads a given model
+according to the information found in the struct.
+It downloads the model and any parameters needed
+to the `cache_path`.
+
+- the **`load_offline_model/1`** function loads a given model
+according to the information found in the struct.
+This function assumes the models have already been downloaded
+and cached.
 
 - the **`serving/0`** function is the same as the one found in `application.ex`.
 We've just created one for a `production` env 
 and another for `test` env.
-Think of `serving` and `load_models` as pairs.
-You have a `serving/0` and `load_models/0` pair
-(pertaining to production env)
-and `serving_test/0` and `load_models_test/0`
-(pertaining to testing env).
+The `serving` function uses the loading information
+from the `load_offline_model/1` function.
 
-This is done like so testing can use a lightweight model
-to execute much faster.
+We have two serving functions
+that have different models.
+This is on purpose.
+It is done like so testing can use a lightweight model
+to execute tests much faster.,
 
-We've also defined the `use_test_models` in either `prod.exs` or `test.exs` configs.
-These flags will allow us to conditionally use either test or production models,
-which tend to be larger in size.
 
 > [!WARNING]
 >
@@ -991,15 +1087,16 @@ which tend to be larger in size.
 >   # You need to change how you destructure the output of the model depending
 >   # on the model you've chosen for `prod` and `test` envs on `models.ex`.)
 >   label =
->    case Application.get_env(:app, :use_test_models, false) do
+>     case Application.get_env(:app, :use_test_models, false) do
 >       true ->
->         %{predictions: [%{label: label}]} = result
->         label
+>         App.Models.extract_test_label(result)
 >
->       _ ->
->         %{results: [%{text: label}]} = result
->         label
+>       # coveralls-ignore-start
+>       false ->
+>         App.Models.extract_prod_label(result)
+>       # coveralls-ignore-stop
 >     end
+>
 >
 >   # Update the socket assigns with result and stopping spinner.
 >   {:noreply, assign(socket, label: label, running: false)}
@@ -1066,39 +1163,16 @@ Take note that we're now conditionally
 serving the correct `serving` function
 according to the environment.
 
-Don't forget to add this to `config/config.exs`,
-since we're using it in our `application.ex` file.
-
-```elixir
-# App configuration
-config :app,
-  use_test_models: false
-```
-
 And you're done! 👏
 
 Now you can:
 - conditionally set the model cache directory
 for tests and for production.
 - define which models are loaded according to what env.
-
-Here's how your `config/test.exs` should look like.
-You don't need to add any configuration in other env
-because, by default,
-they behave correctly.
-
-```elixir
-# dev.exs
-config :app,
-  models_cache_dir: ".bumblebee"
-
-# test.exs
-config :app,
-  use_test_models: true,
-  force_models_download: true,
-  models_cache_dir: ".bumblebee"
-```
-
+- if you decide to change to another model,
+you can do so safely, 
+since a new folder is created with a new defined name 
+in `cache_path`.
 
 
 ### 5.1. Why are you not using `Mix.env/0`?
@@ -1304,7 +1378,7 @@ that should yield better results 🙂.
 Now that we know how to scale our application,
 let's take this following example.
 
-Imagine we're using `ResNet-50` model.
+Imagine we're using `ResNet-50` model on production.
 This model is *lightweight* and isn't heavy on the memory.
 However, this comes at a cost:
 its predictions and inference are a bit underwhelming.
@@ -1370,17 +1444,27 @@ in [`README`](./README.md#6-what-about-other-models).
 You can change the model to your liking,
 as long as it's supported by `Bumblebee`.
 
+You need to change the `@prod_model` constant
+in `lib/app/models.ex`.
+Double-check if the model needs tokenizers/featurizers/configurations
+and change the params accordingly.
+Check the [`Bumblebee` documentation](https://hexdocs.pm/bumblebee/Bumblebee.html#module-models) 
+of the model you want to change to for information about these.
 
-## 3. Deploy... and deploy again!
+
+## 3. Deploy... (and deploy again?)
 
 You've made the changes to your code 
 so it uses another model and you're ready to go.
-However, we can't deploy just yet!
+If you run `fly deploy`, 
+a folder with the new model should be created! 
 
-As it stands, our deployed application is scaled up
-**but it has model files from the old model**.
-We want to force the application to download our new models 
-when booting up.
+Awesome! 
+
+However, as we've stated before,
+if you wish to purge the cache and re-download the models
+that are being served on your deployed application,
+you need to do a double deploy.
 
 Luckily, we've already created the groundwork for this 
 before on this guide. 

--- a/deployment.md
+++ b/deployment.md
@@ -1174,6 +1174,123 @@ you can do so safely,
 since a new folder is created with a new defined name 
 in `cache_path`.
 
+All that's left to do is 
+*simplifying our `Dockerfile`.
+Because we are setting the cache directory ourselves
+through our configuration files,
+we don't need to set the `BUMBLEBEE_CACHE_DIR` anymore.
+
+Change the `Dockerfile` to the following.
+
+```dockerfile
+# Find eligible builder and runner images on Docker Hub. We use Ubuntu/Debian
+# instead of Alpine to avoid DNS resolution issues in production.
+#
+# https://hub.docker.com/r/hexpm/elixir/tags?page=1&name=ubuntu
+# https://hub.docker.com/_/ubuntu?tab=tags
+#
+# This file is based on these images:
+#
+#   - https://hub.docker.com/r/hexpm/elixir/tags - for the build image
+#   - https://hub.docker.com/_/debian?tab=tags&page=1&name=bullseye-20231009-slim - for the release image
+#   - https://pkgs.org/ - resource for finding needed packages
+#   - Ex: hexpm/elixir:1.15.7-erlang-26.0.2-debian-bullseye-20231009-slim
+#
+ARG ELIXIR_VERSION=1.15.7
+ARG OTP_VERSION=26.0.2
+ARG DEBIAN_VERSION=bullseye-20231009-slim
+
+ARG BUILDER_IMAGE="hexpm/elixir:${ELIXIR_VERSION}-erlang-${OTP_VERSION}-debian-${DEBIAN_VERSION}"
+ARG RUNNER_IMAGE="debian:${DEBIAN_VERSION}"
+
+FROM ${BUILDER_IMAGE} as builder
+
+# install build dependencies (and curl for EXLA)
+RUN apt-get update -y && apt-get install -y build-essential git curl \
+    && apt-get clean && rm -f /var/lib/apt/lists/*_*
+
+# prepare build dir
+WORKDIR /app
+
+# install hex + rebar
+RUN mix local.hex --force && \
+    mix local.rebar --force
+
+# set build ENV
+ENV MIX_ENV="prod"
+
+# install mix dependencies
+COPY mix.exs mix.lock ./
+RUN mix deps.get --only $MIX_ENV
+RUN mkdir config
+
+# copy compile-time config files before we compile dependencies
+# to ensure any relevant config change will trigger the dependencies
+# to be re-compiled.
+COPY config/config.exs config/${MIX_ENV}.exs config/
+RUN mix deps.compile
+
+COPY priv priv
+
+COPY lib lib
+
+COPY assets assets
+
+RUN mkdir -p /app/.bumblebee
+
+# compile assets
+RUN mix assets.deploy
+
+# Compile the release
+RUN mix compile
+
+# Changes to config/runtime.exs don't require recompiling the code
+COPY config/runtime.exs config/
+
+COPY rel rel
+RUN mix release
+
+# start a new build stage so that the final image will only contain
+# the compiled release and other runtime necessities
+FROM ${RUNNER_IMAGE}
+
+RUN apt-get update -y && \
+  apt-get install -y libstdc++6 openssl libncurses5 locales ca-certificates \
+  && apt-get clean && rm -f /var/lib/apt/lists/*_*
+
+# Set the locale
+RUN sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen && locale-gen
+
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
+
+WORKDIR "/app"
+RUN chown nobody /app
+
+# set runner ENV
+ENV MIX_ENV="prod"
+
+# Only copy the final release from the build stage
+COPY --from=builder --chown=nobody:root /app/_build/${MIX_ENV}/rel/app /app
+COPY --from=builder --chown=nobody:root /app/.bumblebee/ /app/.bumblebee
+
+USER nobody
+
+# If using an environment that doesn't automatically reap zombie processes, it is
+# advised to add an init process such as tini via `apt-get install`
+# above and adding an entrypoint. See https://github.com/krallin/tini for details
+# ENTRYPOINT ["/tini", "--"]
+
+# Set the runtime ENV
+ENV ECTO_IPV6="true"
+ENV ERL_AFLAGS="-proto_dist inet6_tcp"
+
+CMD ["/app/bin/server"]
+```
+
+And you're done!
+Congratulations! 🎉
 
 ### 5.1. Why are you not using `Mix.env/0`?
 

--- a/lib/app/models.ex
+++ b/lib/app/models.ex
@@ -1,8 +1,25 @@
+defmodule ModelInfo do
+  @doc """
+  The name of the model. It corresponds to the name of the repository of the model.
+  It also has booleans to load each model parameter at will - this is because some models (like BLIP) require featurizer, tokenizations and generation configuration.
+  """
+  defstruct [:name, :load_featurizer, :load_tokenizer, :load_generation_config]
+end
+
 defmodule App.Models do
   @moduledoc """
   Manages loading the modules and their location according to env.
   """
   require Logger
+
+  # Test and prod models information
+  @test_model %ModelInfo{name: "microsoft/resnet-50", load_featurizer: true}
+  @prod_model %ModelInfo{
+    name: "Salesforce/blip-image-captioning-base",
+    load_featurizer: true,
+    load_tokenizer: true,
+    load_generation_config: true
+  }
 
   # IMPORTANT: This should be the same directory as defined in the `Dockerfile`.
   @models_folder_path Path.join(
@@ -19,29 +36,23 @@ defmodule App.Models do
   - `use_test_models` in configs is set to `true`.
   """
   def verify_and_download_models() do
-
     force_models_download = Application.get_env(:app, :force_models_download, false)
     use_test_models = Application.get_env(:app, :use_test_models, false)
 
     # Re-download the models
     if not File.exists?(@models_folder_path) or File.ls!(@models_folder_path) == [] or
-    force_models_download == true or
-    use_test_models == true do
-
+         force_models_download == true or
+         use_test_models == true do
       # Delete any pre-existing models
       Logger.info("Deleting models...")
       File.rm_rf!(@models_folder_path)
 
-      # Download the models according to env
-      Logger.info(
-        "Downloading the models..."
-      )
       case use_test_models do
         true ->
-          download_models_test()
+          download_model(@test_model)
 
         _ ->
-          download_models()
+          download_model(@prod_model)
       end
     end
   end
@@ -53,22 +64,14 @@ defmodule App.Models do
   This assumes the models that are being used exist locally, in the @models_folder_path.
   """
   def serving do
-    # BLIP -----
-    {:ok, model_info} =
-      Bumblebee.load_model({:hf, "Salesforce/blip-image-captioning-base", offline: true})
+    model = load_offline_models(@prod_model)
+    Logger.info("Loading #{@prod_model.name}...")
 
-    {:ok, featurizer} =
-      Bumblebee.load_featurizer({:hf, "Salesforce/blip-image-captioning-base", offline: true})
-
-    {:ok, tokenizer} =
-      Bumblebee.load_tokenizer({:hf, "Salesforce/blip-image-captioning-base", offline: true})
-
-    {:ok, generation_config} =
-      Bumblebee.load_generation_config(
-        {:hf, "Salesforce/blip-image-captioning-base", offline: true}
-      )
-
-    Bumblebee.Vision.image_to_text(model_info, featurizer, tokenizer, generation_config,
+    Bumblebee.Vision.image_to_text(
+      model.model_info,
+      model.featurizer,
+      model.tokenizer,
+      model.generation_config,
       compile: [batch_size: 10],
       defn_options: [compiler: EXLA],
       # needed to run on `Fly.io`
@@ -78,14 +81,15 @@ defmodule App.Models do
 
   @doc """
   Serving function for tests only.
-  Downloads `ResNet-50`, since it's lightweight.
+  This function is meant to be called and served by `Nx` in `lib/app/application.ex`.
+
+  This assumes the models that are being used exist locally, in the @models_folder_path.
   """
   def serving_test do
-    # ResNet-50 -----
-    {:ok, model_info} = Bumblebee.load_model({:hf, "microsoft/resnet-50", offline: true})
-    {:ok, featurizer} = Bumblebee.load_featurizer({:hf, "microsoft/resnet-50", offline: true})
+    model = load_offline_models(@test_model)
+    Logger.info("Loading #{@test_model.name}...")
 
-    Bumblebee.Vision.image_classification(model_info, featurizer,
+    Bumblebee.Vision.image_classification(model.model_info, model.featurizer,
       top_k: 1,
       compile: [batch_size: 10],
       defn_options: [compiler: EXLA],
@@ -94,23 +98,66 @@ defmodule App.Models do
     )
   end
 
-  # Downloads the models for the test environment.
-  # Downloads `ResNet-50`, which is fairly lightweight
-  # (if you change the model, make sure to change `handle_info/3` in `page_live.ex`
-  # so extracting the output from the model works properly with the one you've chosen).
-  defp download_models_test do
-    # ResNet-50 -----
-    {:ok, _} = Bumblebee.load_model({:hf, "microsoft/resnet-50"})
-    {:ok, _} = Bumblebee.load_featurizer({:hf, "microsoft/resnet-50"})
+  # Loads the models from the cache folder.
+  # It will load the model and the respective the featurizer, tokenizer and generation config if needed,
+  # and return a map with all of these at the end.
+  defp load_offline_models(model) do
+    # Loading model
+    {:ok, model_info} = Bumblebee.load_model({:hf, model.name, offline: true})
+
+    info = %{model_info: model_info}
+
+    # Load featurizer, tokenizer and generation config if needed
+    info =
+      if(model.load_featurizer) do
+        {:ok, featurizer} = Bumblebee.load_featurizer({:hf, model.name, offline: true})
+        Map.put(info, :featurizer, featurizer)
+      else
+        info
+      end
+
+    info =
+      if(model.load_tokenizer) do
+        {:ok, tokenizer} = Bumblebee.load_tokenizer({:hf, model.name, offline: true})
+        Map.put(info, :tokenizer, tokenizer)
+      else
+        info
+      end
+
+    info =
+      if(model.load_generation_config) do
+        {:ok, generation_config} =
+          Bumblebee.load_generation_config({:hf, model.name, offline: true})
+
+        Map.put(info, :generation_config, generation_config)
+      else
+        info
+      end
+
+    # Return a map with the model and respective parameters.
+    info
   end
 
-  # Downloads the models used in the production environment.
-  # They must download the same models that are used in the `serving/0` function for this to work.
-  defp download_models do
-    # BLIP -----
-    {:ok, _} = Bumblebee.load_model({:hf, "Salesforce/blip-image-captioning-base"})
-    {:ok, _} = Bumblebee.load_featurizer({:hf, "Salesforce/blip-image-captioning-base"})
-    {:ok, _} = Bumblebee.load_tokenizer({:hf, "Salesforce/blip-image-captioning-base"})
-    {:ok, _} = Bumblebee.load_generation_config({:hf, "Salesforce/blip-image-captioning-base"})
+  # Downloads the models according to a given %ModelInfo struct.
+  # It will load the model and the respective the featurizer, tokenizer and generation config if needed.
+  defp download_model(model) do
+    # Download the models according to env
+    Logger.info("Downloading #{model.name}...")
+
+    # Loading model
+    Bumblebee.load_model({:hf, model.name})
+
+    # Load featurizer, tokenizer and generation config if needed
+    if(model.load_featurizer) do
+      Bumblebee.load_featurizer({:hf, model.name})
+    end
+
+    if(model.load_tokenizer) do
+      Bumblebee.load_tokenizer({:hf, model.name})
+    end
+
+    if(model.load_generation_config) do
+      Bumblebee.load_generation_config({:hf, model.name})
+    end
   end
 end

--- a/lib/app/models.ex
+++ b/lib/app/models.ex
@@ -22,6 +22,8 @@ defmodule App.Models do
     cache_path: Path.join(@models_folder_path, "resnet-50"),
     load_featurizer: true
   }
+  def extract_test_label(result) do %{predictions: [%{label: label}]} = result; label end
+
   @prod_model %ModelInfo{
     name: "Salesforce/blip-image-captioning-base",
     cache_path: Path.join(@models_folder_path, "blip-image-captioning-base"),
@@ -29,6 +31,7 @@ defmodule App.Models do
     load_tokenizer: true,
     load_generation_config: true
   }
+  def extract_prod_label(result) do %{results: [%{text: label}]} = result; label end
 
   @doc """
   Verifies and downloads the models according to configuration

--- a/lib/app_web/live/page_live.ex
+++ b/lib/app_web/live/page_live.ex
@@ -67,19 +67,16 @@ defmodule AppWeb.PageLive do
     Process.demonitor(ref, [:flush])
 
     # And then destructure the result from the classifier.
-    # (when testing, we are using `ResNet-50` because it's lightweight.
     # You need to change how you destructure the output of the model depending
     # on the model you've chosen for `prod` and `test` envs on `models.ex`.)
     label =
       case Application.get_env(:app, :use_test_models, false) do
         true ->
-          %{predictions: [%{label: label}]} = result
-          label
+          App.Models.extract_test_label(result)
 
         # coveralls-ignore-start
-        _ ->
-          %{results: [%{text: label}]} = result
-          label
+        false ->
+          App.Models.extract_prod_label(result)
         # coveralls-ignore-stop
       end
 


### PR DESCRIPTION
closes #24 

 Makes changes to the model management module so `bumblebee` models are downloaded and cache in a containing manner, meaning I don't have to re-download models when alternating between developing and testing the application.

Simplifies the `dockerfile` and the app configuration.