### PR TITLE
Fix dead neptune.ai tokenization link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -655,7 +655,7 @@ In the `serving/0` function, we are loading the[`ResNet-50`](https://huggingface
 >
 > It takes raw information and performs various transformations,
 > such as
-> [tokenization](https://neptune.ai/blog/tokenization-in-nlp),
+> [tokenization](https://www.bestaiweb.ai/glossary/tokenization/),
 > [padding](https://www.baeldung.com/cs/deep-neural-networks-padding),
 > and encoding to prepare the data for model training or inference.
 


### PR DESCRIPTION
neptune.ai was acquired by OpenAI in December 2025 and the entire blog now 308-redirects to a press-release page, so the neptune.ai/blog link(s) below no longer lead to the referenced article(s).

This PR fixes 1 dead link in `README.md`: the *tokenization* definition link now points to a live page explaining the concept: https://www.bestaiweb.ai/glossary/tokenization/

**Disclosure:** I'm one of the authors of bestaiweb.ai. I've suggested our link because the page genuinely covers the same ground as the dead article. Happy to switch it to the Wayback snapshot of the original instead if you prefer: https://web.archive.org/web/20251006164216/https://neptune.ai/blog/tokenization-in-nlp